### PR TITLE
Add (feature) support for rocket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ slab = "0.4.0"
 #svgtypes = "0.1.1"
 svgtypes = { git = "https://github.com/RazrFalcon/svgtypes", rev = "a794d41" }
 
+[dependencies.rocket]
+version = "0.3.12"
+default-features = false
+optional = true
+
 [dev-dependencies]
 time = "0.1"
 bencher = "0.1"
@@ -31,3 +36,6 @@ harness = false
 
 [lib]
 doctest = true
+
+[features]
+rocket-support = ["rocket"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,9 @@ mod attribute_type;
 mod attribute_value;
 mod attributes;
 
+#[cfg(feature = "rocket-support")]
+mod rocket;
+
 
 pub use attribute::*;
 pub use attribute_type::AttributeType;

--- a/src/rocket.rs
+++ b/src/rocket.rs
@@ -1,0 +1,17 @@
+extern crate rocket;
+
+use self::rocket::http::ContentType;
+use self::rocket::request::Request;
+use self::rocket::response::{self, Responder, Response};
+use super::document::Document;
+use std::io::Cursor;
+
+#[cfg(feature = "rocket-support")]
+impl<'r> Responder<'r> for Document {
+    fn respond_to(self, _: &Request) -> response::Result<'r> {
+        Response::build()
+            .sized_body(Cursor::new(self.to_string()))
+            .header(ContentType::new("image", "svg+xml"))
+            .ok()
+    }
+}


### PR DESCRIPTION
This adds support for [Rocket](https://github.com/SergioBenitez/Rocket) to `svgdom`, implementing `Rocket::Responder` for `svgdom::Document` which makes it possible to return the document in a Rocket route.

The Rocket specific part is only included in the `rocket-support` feature.

I just added this for a project and thought I might want to ask upstream for implementing this. If you feel like this is too specific, feel free to close this PR.

I would also happily contribute an example for this use case.